### PR TITLE
Fix for kernel 6.8.0 changes

### DIFF
--- a/src/hws_video.c
+++ b/src/hws_video.c
@@ -304,7 +304,7 @@ static int hws_vidioc_enum_fmt_vid_cap(struct file *file, void *priv_fh,struct v
 		    //printk("%s..pixfmt=%d.\n",__func__,f->index);
 		    f->index = index;
 		    f->type = V4L2_BUF_TYPE_VIDEO_CAPTURE;
-		    strlcpy(f->description, pixfmt->name, sizeof(f->description));
+		    strscpy(f->description, pixfmt->name, sizeof(f->description));
 		    f->pixelformat=pixfmt->fourcc;
 		}
 	}
@@ -3167,7 +3167,7 @@ int hws_video_register(struct hws_pcie_dev *dev)
 		q->io_modes = VB2_READ | VB2_MMAP | VB2_USERPTR;
 		//q->io_modes = VB2_MMAP | VB2_USERPTR | VB2_DMABUF | VB2_READ;
 		q->gfp_flags = GFP_DMA32;
-		q->min_buffers_needed = 2;
+		q->min_queued_buffers = 2;
 		q->drv_priv = &(dev->video[i]);
 		q->buf_struct_size = sizeof(struct hwsvideo_buffer);
 		q->ops = &hwspcie_video_qops;

--- a/src/hws_video.c
+++ b/src/hws_video.c
@@ -3167,7 +3167,11 @@ int hws_video_register(struct hws_pcie_dev *dev)
 		q->io_modes = VB2_READ | VB2_MMAP | VB2_USERPTR;
 		//q->io_modes = VB2_MMAP | VB2_USERPTR | VB2_DMABUF | VB2_READ;
 		q->gfp_flags = GFP_DMA32;
+		#if (LINUX_VERSION_CODE < KERNEL_VERSION(6,8,0))
+		q->min_buffers_needed = 2;
+		#else
 		q->min_queued_buffers = 2;
+		#endif
 		q->drv_priv = &(dev->video[i]);
 		q->buf_struct_size = sizeof(struct hwsvideo_buffer);
 		q->ops = &hwspcie_video_qops;


### PR DESCRIPTION
I was testing Fedora 40 on my machine and I stumbled on a couple of compile problems with this module. This problems are the same that were reported by #7 , so this PR should fix them.

1) The linker can't find the `strlcpy` function anymore. Researching I found out that it seems that it was removed [0][1]. others sources I found about it[2] favor using `strscpy` instead, so I went for that to fix it.

2) The `vb2_queue` struct parameter `min_buffers_needed` [3] doesn't exist anymore, it sees that it's name was changed for `min_queued_buffers` [4]

Making these changes make it compile and work on my env.

[0] https://review.lttng.org/c/lttng-modules/+/11701
[1] https://www.debugpoint.com/linux-kernel-6-8/
[2] https://lwn.net/Articles/905777/
[3] https://elixir.bootlin.com/linux/v6.7.10/source/include/media/videobuf2-core.h#L549
[4] https://elixir.bootlin.com/linux/v6.8/source/include/media/videobuf2-core.h#L549