### PR TITLE
Allow spaces in filepath

### DIFF
--- a/scripts/hws-dkms-install.sh
+++ b/scripts/hws-dkms-install.sh
@@ -54,8 +54,8 @@ install_module ()
         error_exit
     fi
 
-    cp -rvf $HWS_TOP_DIR/src $MODULE_INSTALL_DIR >> $LOGFILE 2>&1 &&
-    cp -rvf $HWS_TOP_DIR/scripts $MODULE_INSTALL_DIR >> $LOGFILE 2>&1
+    cp -rvf "$HWS_TOP_DIR/src" $MODULE_INSTALL_DIR >> $LOGFILE 2>&1 &&
+    cp -rvf "$HWS_TOP_DIR/scripts" $MODULE_INSTALL_DIR >> $LOGFILE 2>&1
     RET=$?
     if [ $RET -ne 0 ] ; then
         echo_string ""


### PR DESCRIPTION
My files are organized in directories with spaces, so I wanted to modify the install script `scripts/hws-dkms-install.sh` to support this. With this PR, the driver installs just fine even if there are spaces in the filepath. If this works for others, perhaps we could remove the warning from the README.

Thank you for sharing this driver! I specifically ordered this capture card because of it's Linux support, based on [this video](https://www.youtube.com/watch?v=RpLASLDXxiM).

Cheers,
Jacob