### PR TITLE
fix: set q->lock for vb2 on kernel 7.0 (wait_prepare/finish removed)

### DIFF
--- a/src/hws.h
+++ b/src/hws.h
@@ -304,6 +304,7 @@ struct hws_vfh_ctx {
     struct vb2_queue    vbq;
     struct list_head    buf_queue;   /* queued hwsvideo_buffer for this fh */
     spinlock_t          qlock;       /* protects buf_queue */
+    struct mutex        qmutex;      /* vb2 q->lock on kernels >= 7.0 (wait_prepare/finish removed) */
     bool                streaming;
     struct hws_video   *video;
     struct list_head    node;        /* link into video->consumers */

--- a/src/hws_video.c
+++ b/src/hws_video.c
@@ -635,6 +635,7 @@ static int hws_open(struct file *file)
     ctx->video = videodev;
     INIT_LIST_HEAD(&ctx->buf_queue);
     spin_lock_init(&ctx->qlock);
+    mutex_init(&ctx->qmutex);
     ctx->streaming = false;
 
     /* v4l2 file-handle */
@@ -657,7 +658,13 @@ static int hws_open(struct file *file)
     q->ops = &hwspcie_video_multi_qops;
     q->mem_ops = &vb2_vmalloc_memops;
     q->timestamp_flags = V4L2_BUF_FLAG_TIMESTAMP_MONOTONIC;
-    q->lock = NULL; /* we use our own locks */
+    #if (LINUX_VERSION_CODE < KERNEL_VERSION(7,0,0))
+    q->lock = NULL; /* pre-7.0: serialized via wait_prepare/wait_finish ops */
+    #else
+    /* 7.0 removed wait_prepare/wait_finish; vb2 now requires q->lock. The queue
+     * is per-open (per ctx), so a per-ctx mutex serializes only this fh. */
+    q->lock = &ctx->qmutex;
+    #endif
     q->dev = &pdx->pdev->dev;
 
     ret = vb2_queue_init(q);


### PR DESCRIPTION
## Problem (#19)

On kernel 7.0, `vb2_ops.wait_prepare`/`wait_finish` were removed and `vb2_core_queue_init()` now requires `q->lock`. `hws_open()` sets `q->lock = NULL`, so with the wait ops gone, `vb2_core_queue_init()` returns `-EINVAL` — `open()` fails and every `VIDIOC_*` call returns "Invalid argument". The device is unusable on 7.0.

The existing "build on kernel 7.0" change already `#if`'d out the wait ops but left `q->lock = NULL`, so the runtime half of the 7.0 port was unfinished. This finishes it.

## Fix

Each `open()` already creates its own per-fh `vb2_queue` (the multi-consumer path), so give each one its own mutex and point `q->lock` at it on >= 7.0. Pre-7.0 behavior (`q->lock = NULL` + `wait_prepare`/`wait_finish`) is unchanged.

- `hws.h`: add `struct mutex qmutex` to `struct hws_vfh_ctx`.
- `hws_video.c`: `mutex_init()` it in `hws_open()`; set `q->lock = &ctx->qmutex` under `#if LINUX_VERSION_CODE >= KERNEL_VERSION(7,0,0)`.

The vb2 callbacks use spinlocks (not the fh ioctl lock), so there is no AB-BA hazard with the per-fh mutex.

## Verification

Tested on an AVMATRIX VC12-4K (PCI `8888:8581`), Ubuntu 26.04, kernel `7.0.0-27-generic`:

- **Before:** `open()` → `-EINVAL`, device unusable.
- **After:** device opens and **captures live video** (real frames at 2560x1440 over HDMI).

Fixes #19.